### PR TITLE
Update from `tui` to newest `ratatui`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 edition = "2021"
 license = "MIT"
 description = "A lightweight translation layer between syntect.rs and tui.rs style types"
-authors = ["Pierre Chanquion <{FORENAME}.{FIRST_FIVE_LETTERS_OF_SURNAME}.io>"]
+authors = ["Pierre Chanquion <{FORENAME}.{FIRST_FIVE_LETTERS_OF_SURNAME}.io>", "Mick Harrigan <mharrigan328@gmail.com>"]
 
 [dependencies]
 custom_error = "1.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ authors = ["Pierre Chanquion <{FORENAME}.{FIRST_FIVE_LETTERS_OF_SURNAME}.io>"]
 
 [dependencies]
 custom_error = "1.9.2"
+ratatui = "0.23.0"
 syntect = "5.0.0"
-tui = "0.19.0"
 
 [dev-dependencies]
 rstest = "0.15"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syntect-tui [![Build Status](https://app.travis-ci.com/chanq-io/syntect-tui.svg?branch=main)](https://app.travis-ci.com/chanq-io/syntect-tui)
 A lightweight translation layer between [syntect](https://github.com/trishume/syntect) and
-[tui-rs](https://github.com/fdehau/tui-rs) style types. If you're building a CLI app with a UI powered by tui.rs and need syntax highlighting, then you may find this crate useful!
+[ratatui](https://github.com/ratatui-org/ratatui) style types. If you're building a CLI app with a UI powered by tui.rs and need syntax highlighting, then you may find this crate useful!
 
 Given the limited scope of this crate I do not have plans to extend existing functionality much further. However, I am open to requests and/or contributions, so feel free to fork and submit a pull request.
 
@@ -17,8 +17,8 @@ For more usage information read the [docs](https://docs.rs/syntect-tui/latest/sy
 ## Example Code
 Building upon [syntect's simple example](https://github.com/trishume/syntect#example-code), here's a
 snippet that parses some rust code, highlights it using syntect and converts it into
-[tui::text::Spans](https://docs.rs/tui/latest/tui/text/struct.Spans.html) ready for rendering in a tui appliction:
-```
+[ratatui::text::Line](https://docs.rs/ratatui/latest/ratatui/text/struct.Line.html) ready for rendering in a tui appliction:
+```rust
 use syntect::easy::HighlightLines;
 use syntect::parsing::SyntaxSet;
 use syntect::highlighting::{ThemeSet, Style};
@@ -44,4 +44,4 @@ for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newli
 ```
 
 ## Licence & Acknowledgements
-Thanks to [trishume](https://github.com/trishume) and [fdehau](https://github.com/fdehau/) for building `sytect` & `tui`! All code is released under the MIT License.
+Thanks to [trishume](https://github.com/trishume), [fdehau](https://github.com/fdehau/), and the [ratatui community](https://github.com/ratatui-org/ratatui) for building `sytect`, `tui`, and `ratatui`! All code is released under the MIT License.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
-//! # syntect-tui
+//! # syntect-ratatui
 //!
-//! `syntect-tui` is a lightweight toolset for converting from text stylised by
+//! `syntect-ratatui` is a lightweight toolset for converting from text stylised by
 //! [syntect](https://docs.rs/syntect/latest/syntect) into stylised text renderable in
-//! [tui](https://docs.rs/tui/0.10.0/tui) applications.
+//! [ratatui](https://docs.rs/ratatui/0.10.0/ratatui) applications.
 //!
 //! Contributions welcome! Feel free to fork and submit a pull request.
 use custom_error::custom_error;
@@ -10,10 +10,10 @@ use custom_error::custom_error;
 custom_error! {
     #[derive(PartialEq)]
     pub SyntectTuiError
-    UnknownFontStyle { bits: u8 } = "Unable to convert syntect::FontStyle into tui::Modifier: unsupported bits ({bits}) value.",
+    UnknownFontStyle { bits: u8 } = "Unable to convert syntect::FontStyle into ratatui::Modifier: unsupported bits ({bits}) value.",
 }
 
-/// Converts a line segment highlighed using [syntect::easy::HighlightLines::highlight_line](https://docs.rs/syntect/latest/syntect/easy/struct.HighlightLines.html#method.highlight_line) into a [tui::text::Span](https://docs.rs/tui/0.10.0/tui/text/struct.Span.html).
+/// Converts a line segment highlighed using [syntect::easy::HighlightLines::highlight_line](https://docs.rs/syntect/latest/syntect/easy/struct.HighlightLines.html#method.highlight_line) into a [ratatui::text::Span](https://docs.rs/ratatui/0.10.0/ratatui/text/struct.Span.html).
 ///
 /// Syntect colours are RGBA while Tui colours are RGB, so colour conversion is lossy. However, if a Syntect colour's alpha value is `0`, then we preserve this to some degree by returning a value of `None` for that colour (i.e. its colourless).
 ///
@@ -26,13 +26,14 @@ custom_error! {
 ///     background: syntect::highlighting::Color { r: 0, g: 0, b: 0, a: 0 },
 ///     font_style: syntect::highlighting::FontStyle::BOLD
 /// };
-/// let expected_style = tui::style::Style {
-///     fg: Some(tui::style::Color::Rgb(255, 0, 0)),
+/// let expected_style = ratatui::style::Style {
+///     fg: Some(ratatui::style::Color::Rgb(255, 0, 0)),
 ///     bg: None,
-///     add_modifier: tui::style::Modifier::BOLD,
-///     sub_modifier: tui::style::Modifier::empty()
+///     underline_color: None,
+///     add_modifier: ratatui::style::Modifier::BOLD,
+///     sub_modifier: ratatui::style::Modifier::empty()
 /// };
-/// let expected_span = tui::text::Span::styled(input_text, expected_style);
+/// let expected_span = ratatui::text::Span::styled(input_text, expected_style);
 /// let actual_span = syntect_tui::into_span((input_style, input_text)).unwrap();
 /// assert_eq!(expected_span, actual_span);
 /// ```
@@ -51,13 +52,13 @@ custom_error! {
 /// let mut h = HighlightLines::new(syntax, &ts.themes["base16-ocean.dark"]);
 /// let s = "pub struct Wow { hi: u64 }\nfn blah() -> u64 {}";
 /// for line in LinesWithEndings::from(s) { // LinesWithEndings enables use of newlines mode
-///     let line_spans: Vec<tui::text::Span> =
+///     let line_spans: Vec<ratatui::text::Span> =
 ///         h.highlight_line(line, &ps)
 ///          .unwrap()
 ///          .into_iter()
 ///          .filter_map(|segment| into_span(segment).ok())
 ///          .collect();
-///     let spans = tui::text::Spans::from(line_spans);
+///     let spans = ratatui::text::Spans::from(line_spans);
 ///     print!("{:?}", spans);
 /// }
 ///
@@ -69,8 +70,8 @@ custom_error! {
 /// All explicit compositions of `BOLD`, `ITALIC` & `UNDERLINE` are supported, however, implicit bitflag coercions are not. For example, even though `FontStyle::from_bits(3)` is coerced to `Some(FontStyle::BOLD | FontStyle::ITALIC)`, we ignore this result as it would be a pain to handle all implicit coercions.
 pub fn into_span<'a>(
     (style, content): (syntect::highlighting::Style, &'a str),
-) -> Result<tui::text::Span<'a>, SyntectTuiError> {
-    Ok(tui::text::Span::styled(
+) -> Result<ratatui::text::Span<'a>, SyntectTuiError> {
+    Ok(ratatui::text::Span::styled(
         String::from(content),
         translate_style(style)?,
     ))
@@ -78,7 +79,7 @@ pub fn into_span<'a>(
 
 /// Converts a
 /// [syntect::highlighting::Style](https://docs.rs/syntect/latest/syntect/highlighting/struct.Style.html)
-/// into a [tui::style::Style](https://docs.rs/tui/0.10.0/tui/style/struct.Style.html).
+/// into a [ratatui::style::Style](https://docs.rs/ratatui/0.10.0/ratatui/style/struct.Style.html).
 ///
 /// Syntect colours are RGBA while Tui colours are RGB, so colour conversion is lossy. However, if a Syntect colour's alpha value is `0`, then we preserve this to some degree by returning a value of `None` for that colour (i.e. its colourless).
 ///
@@ -90,11 +91,12 @@ pub fn into_span<'a>(
 ///     background: syntect::highlighting::Color { r: 0, g: 0, b: 0, a: 0 },
 ///     font_style: syntect::highlighting::FontStyle::BOLD
 /// };
-/// let expected = tui::style::Style {
-///     fg: Some(tui::style::Color::Rgb(255, 0, 0)),
+/// let expected = ratatui::style::Style {
+///     fg: Some(ratatui::style::Color::Rgb(255, 0, 0)),
 ///     bg: None,
-///     add_modifier: tui::style::Modifier::BOLD,
-///     sub_modifier: tui::style::Modifier::empty()
+///     underline_color: None,
+///     add_modifier: ratatui::style::Modifier::BOLD,
+///     sub_modifier: ratatui::style::Modifier::empty()
 /// };
 /// let actual = syntect_tui::translate_style(input).unwrap();
 /// assert_eq!(expected, actual);
@@ -105,25 +107,26 @@ pub fn into_span<'a>(
 /// All explicit compositions of `BOLD`, `ITALIC` & `UNDERLINE` are supported, however, implicit bitflag coercions are not. For example, even though `FontStyle::from_bits(3)` is coerced to `Some(FontStyle::BOLD | FontStyle::ITALIC)`, we ignore this result as it would be a pain to handle all implicit coercions.
 pub fn translate_style(
     syntect_style: syntect::highlighting::Style,
-) -> Result<tui::style::Style, SyntectTuiError> {
-    Ok(tui::style::Style {
+) -> Result<ratatui::style::Style, SyntectTuiError> {
+    Ok(ratatui::style::Style {
         fg: translate_colour(syntect_style.foreground),
         bg: translate_colour(syntect_style.background),
+        underline_color: None,
         add_modifier: translate_font_style(syntect_style.font_style)?,
-        sub_modifier: tui::style::Modifier::empty(),
+        sub_modifier: ratatui::style::Modifier::empty(),
     })
 }
 
 /// Converts a
 /// [syntect::highlighting::Color](https://docs.rs/syntect/latest/syntect/highlighting/struct.Color.html)
-/// into a [tui::style::Color](https://docs.rs/tui/0.10.0/tui/style/enum.Color.html).
+/// into a [ratatui::style::Color](https://docs.rs/ratatui/0.10.0/ratatui/style/enum.Color.html).
 ///
 ///
 /// # Examples
 /// Basic usage:
 /// ```
 /// let input = syntect::highlighting::Color { r: 255, g: 0, b: 0, a: 255 };
-/// let expected = Some(tui::style::Color::Rgb(255, 0, 0));
+/// let expected = Some(ratatui::style::Color::Rgb(255, 0, 0));
 /// let actual = syntect_tui::translate_colour(input);
 /// assert_eq!(expected, actual);
 /// ```
@@ -134,10 +137,12 @@ pub fn translate_style(
 ///     syntect_tui::translate_colour(syntect::highlighting::Color { r: 255, g: 0, b: 0, a: 0 })
 /// );
 /// ```
-pub fn translate_colour(syntect_color: syntect::highlighting::Color) -> Option<tui::style::Color> {
+pub fn translate_colour(
+    syntect_color: syntect::highlighting::Color,
+) -> Option<ratatui::style::Color> {
     match syntect_color {
         syntect::highlighting::Color { r, g, b, a } if a > 0 => {
-            Some(tui::style::Color::Rgb(r, g, b))
+            Some(ratatui::style::Color::Rgb(r, g, b))
         }
         _ => None,
     }
@@ -145,14 +150,14 @@ pub fn translate_colour(syntect_color: syntect::highlighting::Color) -> Option<t
 
 /// Converts a
 /// [syntect::highlighting::FontStyle](https://docs.rs/syntect/latest/syntect/highlighting/struct.FontStyle.html)
-/// into a [tui::style::Modifier](https://docs.rs/tui/0.10.0/tui/style/struct.Modifier.html).
+/// into a [ratatui::style::Modifier](https://docs.rs/ratatui/0.10.0/ratatui/style/struct.Modifier.html).
 ///
 ///
 /// # Examples
 /// Basic usage:
 /// ```
 /// let input = syntect::highlighting::FontStyle::BOLD | syntect::highlighting::FontStyle::ITALIC;
-/// let expected = tui::style::Modifier::BOLD | tui::style::Modifier::ITALIC;
+/// let expected = ratatui::style::Modifier::BOLD | ratatui::style::Modifier::ITALIC;
 /// let actual = syntect_tui::translate_font_style(input).unwrap();
 /// assert_eq!(expected, actual);
 /// ```
@@ -162,9 +167,9 @@ pub fn translate_colour(syntect_color: syntect::highlighting::Color) -> Option<t
 /// All explicit compositions of `BOLD`, `ITALIC` & `UNDERLINE` are supported, however, implicit bitflag coercions are not. For example, even though `FontStyle::from_bits(3)` is coerced to `Some(FontStyle::BOLD | FontStyle::ITALIC)`, we ignore this result as it would be a pain to handle all implicit coercions.
 pub fn translate_font_style(
     syntect_font_style: syntect::highlighting::FontStyle,
-) -> Result<tui::style::Modifier, SyntectTuiError> {
+) -> Result<ratatui::style::Modifier, SyntectTuiError> {
+    use ratatui::style::Modifier;
     use syntect::highlighting::FontStyle;
-    use tui::style::Modifier;
     match syntect_font_style {
         x if x == FontStyle::empty() => Ok(Modifier::empty()),
         x if x == FontStyle::BOLD => Ok(Modifier::BOLD),
@@ -191,9 +196,9 @@ mod tests {
     use rstest::*;
 
     use super::*;
+    use ratatui::style::Modifier;
+    use ratatui::text::Span;
     use syntect::highlighting::{Color as SyntectColour, FontStyle, Style as SyntectStyle};
-    use tui::style::Modifier;
-    use tui::text::Span;
 
     fn fake_syntect_colour(r: u8, g: u8, b: u8, a: u8) -> SyntectColour {
         SyntectColour { r, g, b, a }
@@ -210,9 +215,10 @@ mod tests {
         let content = "syntax";
         let expected = Ok(Span {
             content: std::borrow::Cow::Owned(String::from(content)),
-            style: tui::style::Style {
-                fg: Some(tui::style::Color::Rgb(r, g, b)),
-                bg: Some(tui::style::Color::Rgb(g, b, r)),
+            style: ratatui::style::Style {
+                fg: Some(ratatui::style::Color::Rgb(r, g, b)),
+                bg: Some(ratatui::style::Color::Rgb(g, b, r)),
+                underline_color: None,
                 add_modifier: Modifier::UNDERLINED,
                 sub_modifier: Modifier::empty(),
             },
@@ -229,9 +235,9 @@ mod tests {
             foreground: fake_syntect_colour(r, g, b, 128),
             background: fake_syntect_colour(g, b, r, 128),
         };
-        let expected = Ok(tui::style::Style::default()
-            .fg(tui::style::Color::Rgb(r, g, b))
-            .bg(tui::style::Color::Rgb(g, b, r))
+        let expected = Ok(ratatui::style::Style::default()
+            .fg(ratatui::style::Color::Rgb(r, g, b))
+            .bg(ratatui::style::Color::Rgb(g, b, r))
             .add_modifier(Modifier::UNDERLINED));
         let actual = translate_style(input);
         assert_eq!(expected, actual);
@@ -253,12 +259,12 @@ mod tests {
     #[rstest]
     #[case::with_alpha(
         fake_syntect_colour(012, 123, 234, 128),
-        Some(tui::style::Color::Rgb(012, 123, 234))
+        Some(ratatui::style::Color::Rgb(012, 123, 234))
     )]
     #[case::without_alpha(fake_syntect_colour(012, 123, 234, 0), None)]
     fn check_translate_colour(
         #[case] input: SyntectColour,
-        #[case] expected: Option<tui::style::Color>,
+        #[case] expected: Option<ratatui::style::Color>,
     ) {
         assert_eq!(expected, translate_colour(input));
     }


### PR DESCRIPTION
I updated any references to the old [tui](https://github.com/fdehau/tui-rs) library to now reflect [ratatui](https://github.com/ratatui-org/ratatui).

With this I had to change the implementation of `into_span` to update the color of the underline to match the foreground color. This is because from what I was able to find about `syntect` is that it doesn't support different color underlines while `ratatui` does.

Lastly I updated from the use of the deprecated `Spans` call to now be the corrected `Line`.