### PR TITLE
Bump ratatui dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Pierre Chanquion <{FORENAME}.{FIRST_FIVE_LETTERS_OF_SURNAME}.io>", "
 
 [dependencies]
 custom_error = "1.9.2"
-ratatui = "0.28.1"
+ratatui = "0.29.0"
 syntect = "5.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR bumps the ratatui depedency of this crate, which is needed in order for it to work with newer versions of Ratatui. I ran all tests and verified there are no breaking changes. 

<img width="716" alt="Screenshot 2024-10-28 at 13 54 09" src="https://github.com/user-attachments/assets/09281029-46a8-40f6-997a-50117327fa97">
