### PR TITLE
Reduce dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,11 @@ syntect = { version = "5.0.0", default-features = false }
 [dev-dependencies]
 rstest = "0.22.0"
 syntect = { version = "5.0.0", default-features = false, features = ["parsing", "regex-onig", "default-syntaxes", "default-themes"] }
+
+[features]
+default = ["deep-defaults"]
+## Pulls in the default features of dependencies that were used with default
+## dependencies in syntect_tui 3.5.0. It is recommended to not rely on these
+## and enable them as they are used. This feature is provided as a default for
+## compatibility reasons, and will be removed in a future breaking version.
+deep-defaults = ["ratatui/all-widgets", "ratatui/crossterm", "ratatui/macros", "syntect/default-onig"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ authors = ["Pierre Chanquion <{FORENAME}.{FIRST_FIVE_LETTERS_OF_SURNAME}.io>", "
 [dependencies]
 custom_error = "1.9.2"
 ratatui = "0.29.0"
-syntect = "5.0.0"
+syntect = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]
 rstest = "0.22.0"
+syntect = { version = "5.0.0", default-features = false, features = ["parsing", "regex-onig", "default-syntaxes", "default-themes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Pierre Chanquion <{FORENAME}.{FIRST_FIVE_LETTERS_OF_SURNAME}.io>", "
 
 [dependencies]
 custom_error = "1.9.2"
-ratatui = "0.29.0"
+ratatui = { version = "0.29.0", default-features = false, features = ["underline-color"] }
 syntect = { version = "5.0.0", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
syntect-tui pulls in all the default dependencies of both ratatui and syntect, most of them without need. This prevents users from narrowing the size of their dependency tree to what they actually need.

This PR limits the features to what is actually used. I've tried briefly to make the underline-color thing optional (it pulls crossterm with its whole dependency tree), but I didn't understand all the reasoning in there and it wasn't trivial, so I left it or a later exercise.

I'm not sure what this means in terms of semver. While practically I think that downstreams need to depend on what they use anyway, not selecting feature of public dependencies may be a semver breaking change. If so, I'd be happy to add a new default "dependencies-full" feature that can then be deselected by applications to get the desired slim dependency tree.